### PR TITLE
Add `get_image_type`, Improve `is_image_complete`, and Expand Validation Tests

### DIFF
--- a/src/image_complete/auto.py
+++ b/src/image_complete/auto.py
@@ -1,14 +1,73 @@
+from __future__ import annotations
+
 from io import BytesIO
+from pathlib import Path
 
 from image_complete.base import DEFAULT_CHECK_SIZE
-from image_complete.bmp import is_bmp_complete, is_bmp
-from image_complete.gif import is_gif_complete, is_gif
-from image_complete.jpg import is_jpg_complete, is_jpg
-from image_complete.png import is_png_complete, is_png
-from image_complete.webp import is_webp_complete, is_webp
+from image_complete.bmp import is_bmp, is_bmp_complete
+from image_complete.gif import is_gif, is_gif_complete
+from image_complete.jpg import is_jpg, is_jpg_complete
+from image_complete.png import is_png, is_png_complete
+from image_complete.webp import is_webp, is_webp_complete
+
+EXT_TYPE_MAP = {
+    '.bmp': 'bmp',
+    '.gif': 'gif',
+    '.jpg': 'jpg',
+    '.jpeg': 'jpg',
+    '.png': 'png',
+    '.webp': 'webp'
+}
+
+TYPE_IS_FUNC_MAP = {
+    "bmp": is_bmp,
+    "gif": is_gif,
+    "jpg": is_jpg,
+    "png": is_png,
+    "webp": is_webp
+}
 
 
-def is_image_complete(img, strict=True, check_size=DEFAULT_CHECK_SIZE):
+def get_image_type(img, check_consistency=False) -> str:
+    """
+    Checks whether the image type is supported.
+
+    :param img: the absolute path to the image or a bytes/BytesIO object
+    :type img: str or bytes or BytesIO
+    :param check_consistency: if True then the file type will be determined by both extension and file signature, and they must match. Only used when img is a string (file path).
+    :type check_consistency: bool
+    :return: the file type (bmp, gif, jpg, png, webp) or None if not supported
+    :rtype: str
+    """
+    if isinstance(img, bytes):
+        img = BytesIO(img)
+
+    if isinstance(img, (str, Path)):
+        name = img.lower()
+        for ext, t in EXT_TYPE_MAP.items():
+            if name.endswith(ext):
+                if check_consistency:
+                    func = TYPE_IS_FUNC_MAP.get(t)
+                    if func and func(img):
+                        return t
+                    else:
+                        return 'inconsistent'
+                else:
+                    return t
+        return 'unknown'
+    elif isinstance(img, BytesIO):
+        for t, func in TYPE_IS_FUNC_MAP.items():
+            if func(img):
+                return t
+        return 'unknown'
+    else:
+        raise TypeError(f"Unsupported data type: {type(img)}")
+
+
+def is_image_complete(img,
+                      strict=True,
+                      check_size=DEFAULT_CHECK_SIZE,
+                      check_consistency=False):
     """
     Checks whether the image is complete. Auto-detects the type based on extension.
     If the type is not supported, it will throw an exception.
@@ -19,39 +78,30 @@ def is_image_complete(img, strict=True, check_size=DEFAULT_CHECK_SIZE):
     :type strict: bool
     :param check_size: the number of bytes from the end of the file to look for EOF marker (only used by: gif, jpg, png)
     :type check_size: int
+    :param check_consistency: if True then the file type will be determined by both extension and file signature, and they must match. Only used when img is a string (file path).
+    :type check_consistency: bool
     :return: True if complete
     :rtype: bool
     """
     if isinstance(img, bytes):
         img = BytesIO(img)
 
-    if isinstance(img, str):
-        name = img.lower()
-        if name.endswith(".bmp"):
-            return is_bmp_complete(img, strict=strict)
-        elif name.endswith(".gif"):
-            return is_gif_complete(img, strict=strict, check_size=check_size)
-        elif name.endswith(".jpg") or name.endswith(".jpeg"):
-            return is_jpg_complete(img, strict=strict, check_size=check_size)
-        elif name.endswith(".png"):
-            return is_png_complete(img, strict=strict, check_size=check_size)
-        elif name.endswith(".webp"):
-            return is_webp_complete(img, strict=strict)
-        else:
-            raise Exception("Unsupported file type: " + img)
+    image_type = get_image_type(img, check_consistency=check_consistency)
 
-    elif isinstance(img, BytesIO):
-        if is_bmp(img):
-            return is_bmp_complete(img, strict=strict)
-        elif is_gif(img):
-            return is_gif_complete(img, strict=strict, check_size=check_size)
-        elif is_jpg(img):
-            return is_jpg_complete(img, strict=strict, check_size=check_size)
-        elif is_png(img):
-            return is_png_complete(img, strict=strict, check_size=check_size)
-        elif is_webp(img):
-            return is_webp_complete(img, strict=strict)
-        else:
-            raise Exception("Failed to determine file type!")
+    if image_type == 'unknown':
+        raise ValueError("Failed to determine file type!")
+    elif image_type == 'inconsistent':
+        raise ValueError(
+            "File type is inconsistent between extension and file signature!")
+    elif image_type == "bmp":
+        return is_bmp_complete(img, strict=strict)
+    elif image_type == "gif":
+        return is_gif_complete(img, strict=strict, check_size=check_size)
+    elif image_type == "jpg":
+        return is_jpg_complete(img, strict=strict, check_size=check_size)
+    elif image_type == "png":
+        return is_png_complete(img, strict=strict, check_size=check_size)
+    elif image_type == "webp":
+        return is_webp_complete(img, strict=strict)
     else:
-        raise Exception("Unsupported data type: %s" % str(type(img)))
+        raise ValueError("Failed to determine file type!")

--- a/tests/image_complete_tests/autotest.py
+++ b/tests/image_complete_tests/autotest.py
@@ -1,9 +1,68 @@
+import tempfile
 import unittest
+from pathlib import Path
+
+from image_complete.auto import get_image_type, is_image_complete
+
 from .basetest import ImageCompleteTest
-from image_complete.auto import is_image_complete
+
+
+class TestGetImageType(ImageCompleteTest):
+
+    def test_get_image_type_from_file(self):
+        self.assertEqual("gif", get_image_type(self.data_file("complete.gif")))
+        self.assertEqual("jpg", get_image_type(self.data_file("complete.jpg")))
+        self.assertEqual("png", get_image_type(self.data_file("complete.png")))
+        self.assertEqual("bmp", get_image_type(self.data_file("complete.bmp")))
+        self.assertEqual("webp", get_image_type(self.data_file("complete.webp")))
+
+    def test_get_image_type_from_content(self):
+        self.assertEqual("gif", get_image_type(self.data_content("complete.gif")))
+        self.assertEqual("jpg", get_image_type(self.data_content("complete.jpg")))
+        self.assertEqual("png", get_image_type(self.data_content("complete.png")))
+        self.assertEqual("bmp", get_image_type(self.data_content("complete.bmp")))
+        self.assertEqual("webp", get_image_type(self.data_content("complete.webp")))
+
+    def test_get_image_type_from_bytes(self):
+        with open(self.data_file("complete.jpg"), "rb") as fp:
+            data = fp.read()
+        self.assertEqual("jpg", get_image_type(data))
+
+    def test_get_image_type_consistency(self):
+        self.assertEqual("jpg", get_image_type(self.data_file("complete.jpg"), check_consistency=True))
+        self.assertEqual("unknown", get_image_type(self.data_file("file.blah"), check_consistency=True))
+
+    def test_get_image_type_inconsistent_extension_signature(self):
+        with open(self.data_file("complete.jpg"), "rb") as fp:
+            jpg_data = fp.read()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_png_path = Path(temp_dir) / "actually_jpg.png"
+            fake_png_path.write_bytes(jpg_data)
+
+            self.assertEqual("png", get_image_type(str(fake_png_path)))
+            self.assertEqual("inconsistent", get_image_type(str(fake_png_path), check_consistency=True))
+
+    def test_get_image_type_unsupported(self):
+        self.assertEqual("unknown", get_image_type(self.data_file("file.blah")))
+
+    def test_get_image_type_invalid_input(self):
+        with self.assertRaises(TypeError):
+            get_image_type(123)
 
 
 class TestAuto(ImageCompleteTest):
+
+    def test_inconsistent_type_raises_with_consistency_check(self):
+        with open(self.data_file("complete.jpg"), "rb") as fp:
+            jpg_data = fp.read()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_png_path = Path(temp_dir) / "actually_jpg.png"
+            fake_png_path.write_bytes(jpg_data)
+
+            with self.assertRaises(ValueError):
+                is_image_complete(str(fake_png_path), check_consistency=True)
 
     def test_complete_gif(self):
         self.assertTrue(is_image_complete(self.data_file("complete.gif")))
@@ -172,7 +231,10 @@ def suite():
     :return: the test suite
     :rtype: unittest.TestSuite
     """
-    return unittest.TestLoader().loadTestsFromTestCase(TestAuto)
+    test_suite = unittest.TestSuite()
+    test_suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestGetImageType))
+    test_suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestAuto))
+    return test_suite
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request enhances the image type detection and validation logic in the `image_complete.auto` module and adds comprehensive tests for these features. 

The main improvements include introducing a new `get_image_type` function to robustly determine image types, updating the `is_image_complete` function to use this new logic, and expanding the test suite to cover various scenarios, including optional file extension and file signature consistency checks.

All existing functions retain their original behavior and remain fully backward compatible, with no changes to their previously defined functionality.


**Image type detection and validation improvements:**

* Added a new `get_image_type` function in `auto.py` to determine the image type from a file path, bytes, or `BytesIO` object, with an optional consistency check between file extension and file signature. (`src/image_complete/auto.py`)
* Updated `is_image_complete` to use `get_image_type`, improving error handling for unknown or inconsistent file types and supporting consistency checks. (`src/image_complete/auto.py`)

**Testing enhancements:**

* Added a new `TestGetImageType` test case with tests for image type detection from file paths, content, bytes, consistency checks, unsupported types, and invalid input. (`tests/image_complete_tests/autotest.py`)
* Added tests to verify that `is_image_complete` raises an error when file extension and signature are inconsistent and `check_consistency` is enabled. (`tests/image_complete_tests/autotest.py`)